### PR TITLE
Convert Iguana to Rascal parse trees

### DIFF
--- a/src/util/Iguana.rsc
+++ b/src/util/Iguana.rsc
@@ -37,7 +37,7 @@ void main() {
             '  while n do n := n - 1; x := x + x od
             'end
             ";
-        println(parser(input));
+        iprintln(parser(input));
     }
     catch ParseError(loc l): {
         printn("parse error <l>");

--- a/src/util/Iguana.rsc
+++ b/src/util/Iguana.rsc
@@ -2,17 +2,29 @@ module util::Iguana
 
 extend ParseTree;
 import IO;
+import Grammar;
+import lang::rascal::grammar::definition::Literals;
+
 
 // import lang::rascal::\syntax::Rascal;
-import demo::lang::Pico::Syntax;
+//import demo::lang::Pico::Syntax;
+
+start syntax A = B*;
+syntax B = "b";
 
 alias Parser[&T] = &T (str input, loc origin);
+
 
 @javaClass{util.ParserGenerator}
 java Parser[&T] createParser(type[&T] grammar);
 
+&T expand(&T t) {
+    Grammar g = literals(grammar(t));
+    return type(t.symbol, g.rules);
+}
+
 void main() {
-    Parser[Program] parser = createParser(#Program);
+    Parser[A] parser = createParser(expand(#A));
 
     try {
         str input =
@@ -25,7 +37,7 @@ void main() {
             '  while n do n := n - 1; x := x + x od
             'end
             ";
-        println(parser(input));
+        println(parser("b"));
     }
     catch ParseError(loc l): {
         printn("parse error <l>");

--- a/src/util/Iguana.rsc
+++ b/src/util/Iguana.rsc
@@ -7,10 +7,10 @@ import lang::rascal::grammar::definition::Literals;
 
 
 // import lang::rascal::\syntax::Rascal;
-//import demo::lang::Pico::Syntax;
+import demo::lang::Pico::Syntax;
 
-start syntax A = B*;
-syntax B = "b";
+// start syntax A = B*;
+//syntax B = "b";
 
 alias Parser[&T] = &T (str input, loc origin);
 
@@ -24,7 +24,7 @@ java Parser[&T] createParser(type[&T] grammar);
 }
 
 void main() {
-    Parser[A] parser = createParser(expand(#A));
+    Parser[Program] parser = createParser(expand(#Program));
 
     try {
         str input =
@@ -37,7 +37,7 @@ void main() {
             '  while n do n := n - 1; x := x + x od
             'end
             ";
-        iprintln(parser("b"));
+        println(parser(input));
     }
     catch ParseError(loc l): {
         printn("parse error <l>");

--- a/src/util/Iguana.rsc
+++ b/src/util/Iguana.rsc
@@ -37,7 +37,7 @@ void main() {
             '  while n do n := n - 1; x := x + x od
             'end
             ";
-        println(parser("b"));
+        iprintln(parser("b"));
     }
     catch ParseError(loc l): {
         printn("parse error <l>");

--- a/src/util/ParserGenerator.java
+++ b/src/util/ParserGenerator.java
@@ -7,9 +7,12 @@ import io.usethesource.vallang.type.Type;
 import io.usethesource.vallang.type.TypeFactory;
 import org.iguana.grammar.Grammar;
 import org.iguana.parser.IguanaParser;
+import org.iguana.result.ParserResultOps;
+import org.iguana.traversal.DefaultSPPFToParseTreeVisitor;
 import org.iguana.utils.input.Input;
 import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.RascalValueFactory;
+import org.rascalmpl.values.parsetrees.ITree;
 
 public class ParserGenerator {
     private final IRascalValueFactory vf;
@@ -33,11 +36,11 @@ public class ParserGenerator {
             Input input = Input.fromString(inputString.getValue());
             parser.parse(input);
 
-            System.out.println(parser.getParseTree());
-
-            // use the parser here to turn the string into a tree
-            return vf.character('c')/*parse tree*/;
+            RascalParseTreeBuilder parseTreeBuilder = new RascalParseTreeBuilder(vf, input);
+            DefaultSPPFToParseTreeVisitor<ITree> visitor = new DefaultSPPFToParseTreeVisitor<>(parseTreeBuilder, input, false, new ParserResultOps());
+            ITree result = parser.getSPPF().accept(visitor);
+            System.out.println(result);
+            return result;
         });
     }
-
 }

--- a/src/util/ParserGenerator.java
+++ b/src/util/ParserGenerator.java
@@ -29,6 +29,11 @@ public class ParserGenerator {
         RascalGrammarToIguanaGrammarConverter converter = new RascalGrammarToIguanaGrammarConverter();
         Grammar iguanaGrammar = converter.convert((IConstructor) grammar);
         IguanaParser parser = new IguanaParser(iguanaGrammar);
+        System.out.println(">>>>" + iguanaGrammar.getLayout());
+        System.out.println(">>>>" + parser.getFinalGrammar().getLayout());
+        System.out.println(grammar);
+        System.out.println("-------------------");
+        System.out.println(parser.getFinalGrammar());
 
         return vf.function(ftype, (args, kwArgs) -> {
             // input is a string for now 

--- a/src/util/ParserGenerator.java
+++ b/src/util/ParserGenerator.java
@@ -38,9 +38,7 @@ public class ParserGenerator {
 
             RascalParseTreeBuilder parseTreeBuilder = new RascalParseTreeBuilder(vf, input);
             DefaultSPPFToParseTreeVisitor<ITree> visitor = new DefaultSPPFToParseTreeVisitor<>(parseTreeBuilder, input, false, new ParserResultOps());
-            ITree result = parser.getSPPF().accept(visitor);
-            System.out.println(result);
-            return result;
+            return parser.getSPPF().accept(visitor);
         });
     }
 }

--- a/src/util/ParserGenerator.java
+++ b/src/util/ParserGenerator.java
@@ -29,11 +29,6 @@ public class ParserGenerator {
         RascalGrammarToIguanaGrammarConverter converter = new RascalGrammarToIguanaGrammarConverter();
         Grammar iguanaGrammar = converter.convert((IConstructor) grammar);
         IguanaParser parser = new IguanaParser(iguanaGrammar);
-        System.out.println(">>>>" + iguanaGrammar.getLayout());
-        System.out.println(">>>>" + parser.getFinalGrammar().getLayout());
-        System.out.println(grammar);
-        System.out.println("-------------------");
-        System.out.println(parser.getFinalGrammar());
 
         return vf.function(ftype, (args, kwArgs) -> {
             // input is a string for now 

--- a/src/util/RascalGrammarToIguanaGrammarConverter.java
+++ b/src/util/RascalGrammarToIguanaGrammarConverter.java
@@ -274,6 +274,7 @@ public class RascalGrammarToIguanaGrammarConverter {
 
             ruleBuilder.setLayoutStrategy(layoutStrategy);
 
+            // Skip the start rule, the start rule is generated in Iguana, as it may need some variable threading.
             if (isStart(headDef)) return null;
 
             return ruleBuilder.build();
@@ -307,9 +308,10 @@ public class RascalGrammarToIguanaGrammarConverter {
         private Sequence convertProd(IConstructor cons) throws Throwable {
             Sequence.Builder sequenceBuilder = new Sequence.Builder();
 
-            Symbol first = (Symbol) cons.get("def").accept(this);
-            if (first.getLabel() != null) {
-                sequenceBuilder.setLabel(first.getLabel());
+            // The label for the alternative
+            Symbol def = (Symbol) cons.get("def").accept(this);
+            if (def.getLabel() != null) {
+                sequenceBuilder.setLabel(def.getLabel());
             }
 
             List<Symbol> symbols = (List<Symbol>) cons.get("symbols").accept(this);
@@ -326,6 +328,13 @@ public class RascalGrammarToIguanaGrammarConverter {
             }
 
             sequenceBuilder.addAttribute("prod", cons);
+
+            if (isStart(cons.get("def"))) {
+                assert start != null;
+                // We need to store the start prod definition here for building the parse tree.
+                start = start.copy().addAttribute("prod", cons).build();
+            }
+
             return sequenceBuilder.build();
         }
 

--- a/src/util/RascalGrammarToIguanaGrammarConverter.java
+++ b/src/util/RascalGrammarToIguanaGrammarConverter.java
@@ -240,6 +240,11 @@ public class RascalGrammarToIguanaGrammarConverter {
             return ((IConstructor) value).getName().equals("lex");
         }
 
+        private static boolean isLiteral(IValue value) {
+            if (!(value instanceof IConstructor)) return false;
+            return ((IConstructor) value).getName().equals("lit");
+        }
+
         private static boolean isLayout(IValue value) {
             if (!(value instanceof IConstructor)) return false;
             return ((IConstructor) value).getName().equals("layouts");
@@ -265,8 +270,8 @@ public class RascalGrammarToIguanaGrammarConverter {
             ruleBuilder.addPriorityLevels(priorityLevels);
 
             LayoutStrategy layoutStrategy;
-            // Do not insert layout for the lexical or layout definitions
-            if (isLexical(headDef) || isLayout(headDef)) {
+            // Do not insert layout for the lexical, literal or layout definitions
+            if (isLexical(headDef) || isLayout(headDef) || isLiteral(headDef)) {
                 layoutStrategy = LayoutStrategy.NO_LAYOUT;
             } else {
                 layoutStrategy = LayoutStrategy.INHERITED;

--- a/src/util/RascalGrammarToIguanaGrammarConverter.java
+++ b/src/util/RascalGrammarToIguanaGrammarConverter.java
@@ -55,10 +55,7 @@ public class RascalGrammarToIguanaGrammarConverter {
             IValue next = it.next();
             if (isLayout(next)) {
                 String value = ((IString) ((IConstructor) next).get(0)).getValue();
-                // Skip the default layout definition.
-                if (!value.equals("$default$")) {
-                    layout = Identifier.fromName(value);
-                }
+                layout = Identifier.fromName(value);
             }
         }
         return layout;

--- a/src/util/RascalGrammarToIguanaGrammarConverter.java
+++ b/src/util/RascalGrammarToIguanaGrammarConverter.java
@@ -50,12 +50,15 @@ public class RascalGrammarToIguanaGrammarConverter {
     // Iguana handles layout in a later stage.
     private static Identifier getLayoutDefinition(IMap definitions) {
         Iterator<IValue> it = definitions.iterator();
-        Identifier layout = null;
+        // There is a default layout definition in Rascal grammars: $default = epsilon.
+        Identifier layout = Identifier.fromName("$default");
         while (it.hasNext()) {
             IValue next = it.next();
             if (isLayout(next)) {
                 String value = ((IString) ((IConstructor) next).get(0)).getValue();
-                layout = Identifier.fromName(value);
+                if (!value.equals("$default$")) {
+                    layout = Identifier.fromName(value);
+                }
             }
         }
         return layout;

--- a/src/util/RascalParseTreeBuilder.java
+++ b/src/util/RascalParseTreeBuilder.java
@@ -3,8 +3,7 @@ package util;
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.type.Type;
 import org.iguana.grammar.runtime.RuntimeRule;
-import org.iguana.grammar.symbol.Symbol;
-import org.iguana.grammar.symbol.Terminal;
+import org.iguana.grammar.symbol.*;
 import org.iguana.parsetree.ParseTreeBuilder;
 import org.iguana.regex.Char;
 import org.iguana.regex.CharRange;
@@ -50,10 +49,39 @@ public class RascalParseTreeBuilder implements ParseTreeBuilder<ITree> {
     }
 
     @Override
-    public ITree metaSymbolNode(Symbol symbol, List<ITree> children, int leftExtent, int rightExtent) {
+    public ITree starNode(Star symbol, List<ITree> children, int leftExtent, int rightExtent) {
+        return null;
+    }
+
+    @Override
+    public ITree plusNode(Plus symbol, List<ITree> children, int leftExtent, int rightExtent) {
+        return vf.appl(getRegularDefinition(symbol), children.toArray(ITree[]::new));
+    }
+
+    @Override
+    public ITree optNode(Opt symbol, ITree child, int leftExtent, int rightExtent) {
+        return vf.appl(getRegularDefinition(symbol), new ITree[] { child });
+    }
+
+    @Override
+    public ITree altNode(Alt symbol, ITree child, int leftExtent, int rightExtent) {
+        return vf.appl(getRegularDefinition(symbol), new ITree[] { child });
+    }
+
+    @Override
+    public ITree groupNode(Group symbol, List<ITree> children, int leftExtent, int rightExtent) {
+        return vf.appl(getRegularDefinition(symbol), children.toArray(ITree[]::new));
+    }
+
+    @Override
+    public ITree startNode(Start symbol, List<ITree> children, int leftExtent, int rightExtent) {
+        IConstructor definition = (IConstructor) symbol.getAttributes().get("prod");
+        return vf.appl(definition, children.toArray(ITree[]::new));
+    }
+
+    private IConstructor getRegularDefinition(Symbol symbol) {
         IConstructor definition = (IConstructor) symbol.getAttributes().get("definition");
         Type regular = RascalValueFactory.Production_Regular;
-        IConstructor prod = vf.constructor(regular, definition);
-        return vf.appl(prod, children.toArray(ITree[]::new));
+        return vf.constructor(regular, definition);
     }
 }

--- a/src/util/RascalParseTreeBuilder.java
+++ b/src/util/RascalParseTreeBuilder.java
@@ -39,7 +39,6 @@ public class RascalParseTreeBuilder implements ParseTreeBuilder<ITree> {
     @Override
     public ITree nonterminalNode(RuntimeRule rule, List<ITree> children, int leftExtent, int rightExtent) {
         IConstructor prod = (IConstructor) rule.getAttributes().get("prod");
-        if (prod == null) throw new RuntimeException("prod should not be null for");
         return vf.appl(prod, vf.list(children.toArray(ITree[]::new)));
     }
 
@@ -50,7 +49,7 @@ public class RascalParseTreeBuilder implements ParseTreeBuilder<ITree> {
 
     @Override
     public ITree starNode(Star symbol, List<ITree> children, int leftExtent, int rightExtent) {
-        return null;
+        return vf.appl(getRegularDefinition(symbol), children.toArray(ITree[]::new));
     }
 
     @Override

--- a/src/util/RascalParseTreeBuilder.java
+++ b/src/util/RascalParseTreeBuilder.java
@@ -7,6 +7,7 @@ import org.iguana.grammar.symbol.*;
 import org.iguana.parsetree.ParseTreeBuilder;
 import org.iguana.regex.Char;
 import org.iguana.regex.CharRange;
+import org.iguana.regex.Epsilon;
 import org.iguana.regex.RegularExpression;
 import org.iguana.utils.input.Input;
 import org.rascalmpl.values.IRascalValueFactory;
@@ -29,11 +30,13 @@ public class RascalParseTreeBuilder implements ParseTreeBuilder<ITree> {
     @Override
     public ITree terminalNode(Terminal terminal, int leftExtent, int rightExtent) {
         RegularExpression regex = terminal.getRegularExpression();
+        if (regex instanceof Epsilon) {
+            return null;
+        }
         if (regex instanceof CharRange || regex instanceof Char || regex instanceof org.iguana.regex.Alt<?>) {
             return vf.character(input.charAt(leftExtent));
-        } else {
-            throw new RuntimeException("Regex should be a char, char range or char class");
         }
+        throw new RuntimeException("Regex should be a char, char range or char class, but was: " + regex);
     }
 
     @Override

--- a/src/util/RascalParseTreeBuilder.java
+++ b/src/util/RascalParseTreeBuilder.java
@@ -1,0 +1,59 @@
+package util;
+
+import io.usethesource.vallang.IConstructor;
+import io.usethesource.vallang.type.Type;
+import org.iguana.grammar.runtime.RuntimeRule;
+import org.iguana.grammar.symbol.Symbol;
+import org.iguana.grammar.symbol.Terminal;
+import org.iguana.parsetree.ParseTreeBuilder;
+import org.iguana.regex.Char;
+import org.iguana.regex.CharRange;
+import org.iguana.regex.RegularExpression;
+import org.iguana.utils.input.Input;
+import org.rascalmpl.values.IRascalValueFactory;
+import org.rascalmpl.values.RascalValueFactory;
+import org.rascalmpl.values.parsetrees.ITree;
+
+import java.util.List;
+import java.util.Set;
+
+public class RascalParseTreeBuilder implements ParseTreeBuilder<ITree> {
+
+    private final IRascalValueFactory vf;
+    private final Input input;
+
+    public RascalParseTreeBuilder(IRascalValueFactory vf, Input input) {
+        this.vf = vf;
+        this.input = input;
+    }
+
+    @Override
+    public ITree terminalNode(Terminal terminal, int leftExtent, int rightExtent) {
+        RegularExpression regex = terminal.getRegularExpression();
+        if (regex instanceof CharRange || regex instanceof Char || regex instanceof org.iguana.regex.Alt<?>) {
+            return vf.character(input.charAt(leftExtent));
+        } else {
+            throw new RuntimeException("Regex should be a char, char range or char class");
+        }
+    }
+
+    @Override
+    public ITree nonterminalNode(RuntimeRule rule, List<ITree> children, int leftExtent, int rightExtent) {
+        IConstructor prod = (IConstructor) rule.getAttributes().get("prod");
+        if (prod == null) throw new RuntimeException("prod should not be null for");
+        return vf.appl(prod, vf.list(children.toArray(ITree[]::new)));
+    }
+
+    @Override
+    public ITree ambiguityNode(Set<ITree> node) {
+        return vf.amb(vf.set(node.toArray(ITree[]::new)));
+    }
+
+    @Override
+    public ITree metaSymbolNode(Symbol symbol, List<ITree> children, int leftExtent, int rightExtent) {
+        IConstructor definition = (IConstructor) symbol.getAttributes().get("definition");
+        Type regular = RascalValueFactory.Production_Regular;
+        IConstructor prod = vf.constructor(regular, definition);
+        return vf.appl(prod, children.toArray(ITree[]::new));
+    }
+}


### PR DESCRIPTION
A next step in converting Iguana to Rascal Parse trees. The Pico language parse trees can be converted from Iguana to Rascal.